### PR TITLE
Document internal docs agents

### DIFF
--- a/components/ProtectedRoute.tsx
+++ b/components/ProtectedRoute.tsx
@@ -1,3 +1,12 @@
+/**
+ * PURPOSE: Gate client routes until Memberstack confirms session and role
+ * CONTEXT: Router enforces redirect paths for login, onboarding, and unauthorized flows
+ * DEPENDENCIES: useMemberstack useRouter
+ * RELATED_DOCS: @ref: docs/components/ProtectedRoute.md#protected_route_overview
+ * OWNERSHIP: web_app
+ * DATA_CLASS: internal
+ * ORIGIN: ai
+ */
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useMemberstack } from '../hooks/useMemberstack';

--- a/docs/_index.json
+++ b/docs/_index.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.0",
+  "generated_at": "2025-02-15T00:00:00Z",
+  "pages": [
+    {
+      "path": "docs/agents/docs_writer_agent.md",
+      "slug": "docs-writer-agent",
+      "data_class": "internal",
+      "public_url": null,
+      "anchors": [
+        "docs_writer_agent_decisions",
+        "docs_writer_agent_edges",
+        "docs_writer_agent_faq",
+        "docs_writer_agent_migration",
+        "docs_writer_agent_overview",
+        "docs_writer_agent_sequence"
+      ]
+    },
+    {
+      "path": "docs/agents/docs_sync_agent.md",
+      "slug": "docs-sync-agent",
+      "data_class": "internal",
+      "public_url": null,
+      "anchors": [
+        "docs_sync_agent_decisions",
+        "docs_sync_agent_edges",
+        "docs_sync_agent_faq",
+        "docs_sync_agent_migration",
+        "docs_sync_agent_overview",
+        "docs_sync_agent_sequence"
+      ]
+    },
+    {
+      "path": "docs/components/ProtectedRoute.md",
+      "slug": "protected-route",
+      "data_class": "internal",
+      "public_url": null,
+      "anchors": [
+        "protected_route_decisions",
+        "protected_route_edges",
+        "protected_route_faq",
+        "protected_route_migration",
+        "protected_route_overview",
+        "protected_route_sequence"
+      ]
+    }
+  ]
+}

--- a/docs/agents/docs_sync_agent.md
+++ b/docs/agents/docs_sync_agent.md
@@ -1,0 +1,37 @@
+```docmeta
+{
+  "title": "Docs sync agent specification",
+  "slug": "docs-sync-agent",
+  "data_class": "internal",
+  "origin": "ai",
+  "owners": ["platform_docs"],
+  "public_url": null,
+  "refs": [],
+  "test_refs": ["docs_sync_anchor_001", "docs_sync_testref_002"],
+  "last_review": "2025-02-15",
+  "llm_reading_order": ["overview", "sequence", "decisions", "edges", "migration", "faq"]
+}
+```
+
+## Overview {#docs_sync_agent_overview}
+Docs sync agent keeps anchors, refs, and tests aligned. It updates the index so crawlers stay fast.
+
+## Sequence {#docs_sync_agent_sequence}
+1. Parse changed files for RELATED_DOCS lines and ASSERTS tags.
+2. Verify anchors exist or queue stub docs when missing.
+3. Check asserted tests against the known list and note gaps.
+4. Refresh docs/_index.json with sorted anchors and saved metadata.
+
+## Key decisions {#docs_sync_agent_decisions}
+* Never touch code logic to isolate documentation changes. Owner platform_docs. 2024-12-01
+* Sort anchor lists to reduce merge churn. Owner platform_docs. 2025-01-10
+
+## Edges {#docs_sync_agent_edges}
+* Anchor missing in docs. Agent emits stub with empty sections. Test id docs_sync_anchor_001
+* Assert id unknown. Agent flags test gap and adds TODO note. Test id docs_sync_testref_002
+
+## Migration {#docs_sync_agent_migration}
+* Plan diff aware index writer to avoid rewriting unchanged pages on large merges.
+
+## FAQ {#docs_sync_agent_faq}
+* Why not batch docs updates? Small commits keep review focused and surface anchor drift early.

--- a/docs/agents/docs_writer_agent.md
+++ b/docs/agents/docs_writer_agent.md
@@ -1,0 +1,37 @@
+```docmeta
+{
+  "title": "Docs writer agent specification",
+  "slug": "docs-writer-agent",
+  "data_class": "internal",
+  "origin": "ai",
+  "owners": ["platform_docs"],
+  "public_url": null,
+  "refs": [],
+  "test_refs": ["docs_writer_smoke_001", "docs_writer_anchor_002"],
+  "last_review": "2025-02-15",
+  "llm_reading_order": ["overview", "sequence", "decisions", "edges", "migration", "faq"]
+}
+```
+
+## Overview {#docs_writer_agent_overview}
+Docs writer agent drafts internal pages. It follows comment links and writes guides that stay short and direct.
+
+## Sequence {#docs_writer_agent_sequence}
+1. Read headers from related code paths.
+2. Build docmeta with owners, data class, and review date.
+3. Write anchored sections with plain guidance and placeholder examples.
+4. Emit docs_update, ref_map, review notes, and quality metrics.
+
+## Key decisions {#docs_writer_agent_decisions}
+* Keep grade level near eight for fast onboarding. Owner platform_docs. 2024-12-01
+* Require anchors that match RELATED_DOCS entries to avoid ref drift. Owner platform_docs. 2025-01-10
+
+## Edges {#docs_writer_agent_edges}
+* Missing RELATED_DOCS data. Agent emits violation and stops. Test id docs_writer_smoke_001
+* Anchor mismatch found during review. Agent regenerates section names. Test id docs_writer_anchor_002
+
+## Migration {#docs_writer_agent_migration}
+* Plan glossary support so repeated terms link once metadata schema expands.
+
+## FAQ {#docs_writer_agent_faq}
+* Why emit quality scores? Scores let reviewers spot tone or coverage regressions without re-reading every doc.

--- a/docs/components/ProtectedRoute.md
+++ b/docs/components/ProtectedRoute.md
@@ -1,0 +1,38 @@
+```docmeta
+{
+  "title": "Protected route guard",
+  "slug": "protected-route",
+  "data_class": "internal",
+  "origin": "ai",
+  "owners": ["web_app"],
+  "public_url": null,
+  "refs": [
+    {"code": "components/ProtectedRoute.tsx", "symbol": "ProtectedRoute", "asserts": []}
+  ],
+  "test_refs": [],
+  "last_review": "2025-02-15",
+  "llm_reading_order": ["overview", "sequence", "decisions", "edges", "migration", "faq"]
+}
+```
+
+## Overview {#protected_route_overview}
+ProtectedRoute waits for Memberstack to finish loading. It decides whether to show children or redirect visitors based on the active role.
+
+## Sequence {#protected_route_sequence}
+1. Watch session, role, and router state from hooks.
+2. Block render during Memberstack load to avoid flicker.
+3. Redirect to login, onboarding, or unauthorized routes when access fails.
+
+## Key decisions {#protected_route_decisions}
+* Keep routing logic in the component to avoid duplicated checks. Owner web_app. 2025-02-15
+* Allow admins through every gated screen to unblock urgent support. Owner web_app. 2025-02-15
+
+## Edges {#protected_route_edges}
+* Memberstack returns no role after load. Route visitor to onboarding for role capture.
+* Router push fails because of network loss. Leave spinner so user can retry navigation.
+
+## Migration {#protected_route_migration}
+* Replace console logging with structured telemetry once logging backend is ready.
+
+## FAQ {#protected_route_faq}
+* Why return null on denied access? It prevents flash of protected UI while router redirects the visitor.


### PR DESCRIPTION
## Summary
- add documentation pages for docs_writer_agent and docs_sync_agent with structured metadata and anchored sections
- register the new documentation entries in docs/_index.json for crawler support

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e80ec99f608324aef6b12231751dbe