### PR TITLE
Add middleware to secure API routes with token

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server"
+
+export function middleware(req: Request) {
+  const expected = process.env.API_ACCESS_TOKEN
+  const got = req.headers.get("authorization") || ""
+
+  const ok = Boolean(expected) && got.startsWith("Bearer ") && got.slice(7).trim() === expected
+
+  const isApi = req.url.includes("/api/")
+  if (isApi && !ok) {
+    return new NextResponse("Forbidden", { status: 403 })
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ["/api/:path*"]
+}


### PR DESCRIPTION
## Summary
- add a Next.js middleware that checks API requests for the expected bearer token
- block API access with a 403 response when the authorization header is missing or incorrect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8232b169c83249d3a1b1744301753