### PR TITLE
Add health check API route

### DIFF
--- a/pages/api/health.ts
+++ b/pages/api/health.ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json({ ok: true, time: new Date().toISOString() })
+}


### PR DESCRIPTION
## Summary
- add an API route at `/api/health` that returns a JSON health payload

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8272c7c9483248b505afabf4b9196