### PR TITLE
Add Dockerfile for building and running Node app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use the official Node 18 LTS image
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files and install deps
+COPY package*.json ./
+RUN npm ci
+
+# Copy rest of the app and build it
+COPY . .
+RUN npm run build
+
+# Production image
+FROM node:18-alpine
+WORKDIR /app
+
+ENV NODE_ENV=production
+COPY --from=builder /app ./
+
+EXPOSE 8080
+
+# Start the app
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds the project with npm ci and npm run build
- copy the built application into a production Node 18 Alpine image and expose port 8080

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e828dfabf883249b3b6930fb9179d0