### PR TITLE
Update memberstack script to use live app id

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -7,7 +7,7 @@ export default function Document() {
         <link rel="icon" href="/favicon.ico" />
         <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
         <script 
-          data-memberstack-app={process.env.NEXT_PUBLIC_MEMBERSTACK_APP_ID || "app_placeholder"} 
+          data-memberstack-id={process.env.NEXT_PUBLIC_MEMBERSTACK_APP_ID} 
           src="https://static.memberstack.com/scripts/v2/memberstack.js" 
           async
         ></script>


### PR DESCRIPTION
Correct Memberstack script attribute from `data-memberstack-app` to `data-memberstack-id` to resolve the 'test site' display issue.

The Memberstack script was failing to load the correct application ID because it was looking for `data-memberstack-app` instead of the correct `data-memberstack-id` attribute, causing the site to remain in test mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb1ff2ed-3379-4bda-a6e3-5c83046df965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb1ff2ed-3379-4bda-a6e3-5c83046df965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Memberstack script to `data-memberstack-id` using `NEXT_PUBLIC_MEMBERSTACK_APP_ID` to load the correct app.
> 
> - **Auth/Integration**:
>   - Update Memberstack script in `pages/_document.tsx` to use `data-memberstack-id` (from `process.env.NEXT_PUBLIC_MEMBERSTACK_APP_ID`) instead of `data-memberstack-app`.
>   - Removes fallback placeholder, relying solely on the env var.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0587ab48d1d5bcdb66d092d8e30d4495423bb9e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->